### PR TITLE
fix: handle missing temp/swap metrics safely

### DIFF
--- a/utils/system.py
+++ b/utils/system.py
@@ -8,6 +8,20 @@ from config import ALERT_THRESHOLDS, OWNER_IDS, SYSTEM_MONITORING_INTERVAL
 from utils.format import format_bytes
 
 
+def to_float(value, default=0.0) -> float:
+    if isinstance(value, (int, float)):
+        return float(value)
+
+    if isinstance(value, str):
+        normalized = value.strip().replace("°C", "")
+        try:
+            return float(normalized)
+        except ValueError:
+            return float(default)
+
+    return float(default)
+
+
 def get_distro():
     if platform.system() == "Linux":
         try:
@@ -127,6 +141,7 @@ def get_network_traffic():
 
 def make_bar(percent: float, size: int = 8) -> str:
     """Returns a visual progress bar string, like [██████░░░░░░]"""
+    percent = to_float(percent, 0)
     filled_length = int(size * percent / 100)
     bar = "█" * filled_length + "░" * (size - filled_length)
     return f"[{bar}]"
@@ -146,8 +161,8 @@ async def monitoring_load(bot: Bot):
             "cpu": get_cpu(),
             "ram": get_ram(),
             "disk": get_disk(),
-            "swap": get_swap_usage(),
-            "cpu_temp": float(get_cpu_temperature().replace("°C", "") or 0),
+            "swap": to_float(get_swap_usage(), 0),
+            "cpu_temp": to_float(get_cpu_temperature(), 0),
         }
 
         for key, value in metrics.items():


### PR DESCRIPTION
## Problem
The bot crashes with a `ValueError` when system metrics (CPU temperature or Swap) return non-numeric values like `"-"` on certain systems.

> **If this change does not align with the project's expectations, please feel free to close this PR.**

**Error Log:**
```text
(venv) re@m:~/apps/server-manager-bot$ python main.py
02:28:56 | INFO | __main__:<module> | Bot starting...
02:28:56 | INFO | __main__:main | Bot sucess started
Task exception was never retrieved
future: <Task finished name='Task-4' coro=<monitoring_load() done, defined at /home/re/apps/server-manager-bot/utils/system.py:135> exception=ValueError("could not convert string to float: '-'")>
Traceback (most recent call last):
  File "/home/re/apps/server-manager-bot/utils/system.py", line 150, in monitoring_load
    "cpu_temp": float(get_cpu_temperature().replace("°C", "") or 0),
ValueError: could not convert string to float: '-'
^CReceived SIGINT signal
```

## Solution

Added a helper function `to_float(value, default=0.0)` to safely parse metric values. It handles integers, floats, and strings (stripping units like `°C`), returning a default value for invalid inputs instead of raising an exception.

Updated `make_bar`, `monitoring_load` to use this new helper for `swap` and `cpu_temp`.

## Testing

Verified the bot starts successfully and monitors metrics even when sensor data returns `"-"` or empty strings.
